### PR TITLE
[AIRFLOW-5113] Support icon url in slack web hook	

### DIFF
--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -48,6 +48,8 @@ class SlackWebhookHook(HttpHook):
     :type username: str
     :param icon_emoji: The emoji to use as icon for the user posting to Slack
     :type icon_emoji: str
+    :param icon_url: The icon image URL string to use in place of the default icon.
+    :type icon_url: str
     :param link_names: Whether or not to find and link channel and usernames in your
                        message
     :type link_names: bool
@@ -62,6 +64,7 @@ class SlackWebhookHook(HttpHook):
                  channel=None,
                  username=None,
                  icon_emoji=None,
+                 icon_url=None,
                  link_names=False,
                  proxy=None,
                  *args,
@@ -74,6 +77,7 @@ class SlackWebhookHook(HttpHook):
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
+        self.icon_url = icon_url
         self.link_names = link_names
         self.proxy = proxy
 
@@ -110,6 +114,8 @@ class SlackWebhookHook(HttpHook):
             cmd['username'] = self.username
         if self.icon_emoji:
             cmd['icon_emoji'] = self.icon_emoji
+        if self.icon_url:
+            cmd['icon_url'] = self.icon_url
         if self.link_names:
             cmd['link_names'] = 1
         if self.attachments:

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -47,6 +47,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :type username: str
     :param icon_emoji: The emoji to use as icon for the user posting to Slack
     :type icon_emoji: str
+    :param icon_url: The icon image URL string to use in place of the default icon.
+    :type icon_url: str
     :param link_names: Whether or not to find and link channel and usernames in your
                        message
     :type link_names: bool
@@ -66,6 +68,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
                  channel=None,
                  username=None,
                  icon_emoji=None,
+                 icon_url=None,
                  link_names=False,
                  proxy=None,
                  *args,
@@ -80,6 +83,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
+        self.icon_url = icon_url
         self.link_names = link_names
         self.proxy = proxy
         self.hook = None
@@ -96,6 +100,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
             self.channel,
             self.username,
             self.icon_emoji,
+            self.icon_url,
             self.link_names,
             self.proxy
         )

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -37,6 +37,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         'channel': '#general',
         'username': 'SlackMcSlackFace',
         'icon_emoji': ':hankey:',
+        'icon_url': 'https://airflow.apache.org/_images/pin_large.png',
         'link_names': True,
         'proxy': 'https://my-horrible-proxy.proxyist.com:8080'
     }
@@ -44,6 +45,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         'channel': _config['channel'],
         'username': _config['username'],
         'icon_emoji': _config['icon_emoji'],
+        'icon_url': _config['icon_url'],
         'link_names': 1,
         'attachments': _config['attachments'],
         'text': _config['message']

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -36,6 +36,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         'channel': '#general',
         'username': 'SlackMcSlackFace',
         'icon_emoji': ':hankey',
+        'icon_url': 'https://airflow.apache.org/_images/pin_large.png',
         'link_names': True,
         'proxy': 'https://my-horrible-proxy.proxyist.com:8080'
     }
@@ -62,6 +63,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         self.assertEqual(self._config['channel'], operator.channel)
         self.assertEqual(self._config['username'], operator.username)
         self.assertEqual(self._config['icon_emoji'], operator.icon_emoji)
+        self.assertEqual(self._config['icon_url'], operator.icon_url)
         self.assertEqual(self._config['link_names'], operator.link_names)
         self.assertEqual(self._config['proxy'], operator.proxy)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
